### PR TITLE
M20-592 Accelerometer... X/Y/Z axes

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -24,7 +24,7 @@ const motion = function (isStage, targetId) {
                 </shadow>
             </value>
             <value name="SIDE">
-                    <field>left</field>
+                    <field></field>
             </value>
         </block>
 
@@ -784,7 +784,11 @@ const sensing = function (isStage) {
     <category name="%{BKY_CATEGORY_SENSING}" id="sensing" colour="#4CBFE6" secondaryColour="#2E8EB8">
         ${isStage ? '' : `
 
-            <block type="mv2_accelerometer" />
+            <block type="mv2_accelerometerX" />
+
+            <block type="mv2_accelerometerY" />
+
+            <block type="mv2_accelerometerZ" />
 
             <block type="mv2_batteryLevel" />
 


### PR DESCRIPTION
Replaced single accelerometer block with individual blocks for
each axis.

### Resolves

- Resolves #M20-592 (Jira)

### Proposed Changes

Replace single accelerometer block with individual axes.

### Reason for Changes

One block alone is not viable

### Test Coverage

n/a

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [X] Chrome 
 * [X] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
