### PR TITLE
M20-606 Marty Sounds (Scratch)

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -622,10 +622,8 @@ const sound = function (isStage, targetId, soundName) {
         <!--Marty blocks-->
 
         <block type="mv2_playSound" >
-            <value name="FILENAME">
-                <shadow type="text">
-                    <field name="TEXT"></field>
-                </shadow>
+            <value name="SOUND">
+                    <field name="SOUND"></field>
             </value>
         </block>
 


### PR DESCRIPTION
Modified 'play sound' block to use a hardcoded dropdown list of sounds.

### Resolves

- Resolves #M20-606 (Jira)

### Proposed Changes

Adds a dropdown list of hardcoded filenames to the sounds block

### Reason for Changes

While a less rigid method for using sounds would be good in the future, this is necessary for demonstrating the 'play sound' behaviour

### Test Coverage

n/a

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [x] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
