### PR TITLE
Flash signal bars when rssi == 0

### DIFF
--- a/src/components/marty-signal-strength/marty-signal-strength.css
+++ b/src/components/marty-signal-strength/marty-signal-strength.css
@@ -1,3 +1,15 @@
+.signal-flash {
+    opacity: 1;
+    animation: fade 2s linear infinite;
+}
+
+
+@keyframes fade {
+  0%,100% { opacity: 0 }
+  50% { opacity: 1 }
+}
+
+
 .signal-strength-container {
     display: flex;
     flex-direction: row;

--- a/src/components/marty-signal-strength/marty-signal-strength.jsx
+++ b/src/components/marty-signal-strength/marty-signal-strength.jsx
@@ -21,9 +21,10 @@ class MartySignalStrength extends React.Component {
 
     render () {
         const {rssi} = this.state;
+        const flash = rssi == 0 ? styles.signalFlash : '';
         return (
             <div
-                className={styles.signalStrengthContainer}
+                className={`${flash} ${styles.signalStrengthContainer}`}
             >
                 <div
                     className={styles.signalBar}


### PR DESCRIPTION
When no Marty is connected the rssi appears to be set to 0.

This was resulting in the signal bars showing full signal, when there was no Marty

This is a quick change to flash the signal bars when rssi is 0, but there should be a better way of triggering when a marty is connected - for example the message rx rate as shown in the diagnostics screen