### PR TITLE
Feature/addon tweaks

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -524,8 +524,8 @@ const looks = function (isStage, targetId, costumeName, backdropName) {
             <value>
                 <field name="BOARDTYPE"></field>
             </value>
-            <value>
-                <field name="COLOUR"></field>
+            <value name="COLOR">
+                <shadow type="colour_picker"/>
             </value>
         </block>
 
@@ -533,8 +533,8 @@ const looks = function (isStage, targetId, costumeName, backdropName) {
             <value>
                 <field name="BOARDTYPE"></field>
             </value>
-            <value>
-                <field name="COLOUR"></field>
+            <value name="COLOR">
+                <shadow type="colour_picker"/>
             </value>
             <value>
                 <field name="REGION"></field>

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -182,7 +182,7 @@ const motion = function (isStage, targetId) {
 
         <block type="mv2_wiggle" />
 
-        <block type="mv2_grabberArmBasic" >
+        <block type="mv2_gripperArmBasic" >
             <value name="MOVETIME">
                 <shadow type="math_number">
                     <field name="NUM">1</field>
@@ -195,7 +195,7 @@ const motion = function (isStage, targetId) {
             </value>
         </block>
 
-        <block type="mv2_grabberArmTimed" >
+        <block type="mv2_gripperArmTimed" >
             <value name="MOVETIME">
                 <shadow type="math_number">
                     <field name="NUM">1</field>


### PR DESCRIPTION
### Proposed Changes

- Changes name of grabber to gripper
- Changes LED color setting blocks to use the scratch color picker

### Reason for Changes

- As agreed, we'll call the grabbing hand a gripper going forwards
- Using the color picker allows users a wider range of choice of colours

### Test Coverage

-
Tested with disco Marty boards on Android app

### Browser Coverage


Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [x] Chrome
