### PR TITLE
Change wording of not connected message when user is on WiFi Scratch

### DIFF
--- a/src/lib/vm-listener-hoc.jsx
+++ b/src/lib/vm-listener-hoc.jsx
@@ -81,8 +81,13 @@ const vmListenerHOC = function (WrappedComponent) {
         handleProjectRunStart () {
             // eslint-disable-next-line no-undef
             if (!mv2.isConnected) {
-                // eslint-disable-next-line no-alert
-                alert('You are not currently connected to a Marty. Please close scratch and connect.');
+                if (mv2.isInApp){
+                    // eslint-disable-next-line no-alert
+                    alert('You are not currently connected to a Marty. Please close scratch and connect.');
+                } else {
+                    // eslint-disable-next-line no-alert
+                    alert('You are not currently connected to a Marty. Please open the "Connect/Configure" tab and connect');
+                }
             }
             this.props.onProjectRunStart();
         }


### PR DESCRIPTION
### Resolves

When using the web interface, the user is presented with the message "You are not currently connected to a Marty. Please close scratch and connect." when they try to run the code. They should be told to open the connection tab

### Proposed Changes

Uses the mv2.isInApp boolean to choose which wording to present to the user, and advise them to open the connect/configure tab if they're no in the app
