### PR TITLE
Remove connect by IP block

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -783,13 +783,6 @@ const events = function (isStage) {
 const control = function (isStage) {
     return `
     <category name="%{BKY_CATEGORY_CONTROL}" id="control" colour="#FFAB19" secondaryColour="#CF8B17">
-        <block type="mv2_set_ip" >
-            <value name="IP">
-                <shadow type="text">
-                    <field name="TEXT">192.168.0.27</field>
-                </shadow>
-            </value>
-        </block>
         <block type="control_wait">
             <value name="DURATION">
                 <shadow type="math_positive_number">


### PR DESCRIPTION
### Resolves

Removes the obsolete connect to Marty on IP block from the control section

### Proposed Changes

Removes the obsolete connect to Marty on IP block from the control section

### Reason for Changes

Block has been obsolete for a long time and should not have been included in the build

