### PR TITLE
made the save-load list scrollable

### DIFF
--- a/src/components/marty-save-load/save-load.css
+++ b/src/components/marty-save-load/save-load.css
@@ -41,6 +41,18 @@
     background-color: $ui-tertiary;
 }
 
+.saveList{
+    margin:4px, 4px;
+    padding:4px;
+    height: 275px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    text-align:justify;
+    display: flex;
+    flex-direction: column;
+    margin-top: 10;
+}
+
 .error {
     color: $error-light;
     text-align: center;

--- a/src/components/marty-save-load/save-load.jsx
+++ b/src/components/marty-save-load/save-load.jsx
@@ -160,7 +160,7 @@ class SaveLoad extends React.Component {
                         style={{flex: 1}}
                     >
                         <div>Your Files:</div>
-                        <div style={{display: 'flex', flexDirection: 'column', marginTop: 10}}>
+                        <div className={styles.saveList} >
                             {fileNames.sort().map((key, index) => (
                                 <div
                                     key={key}


### PR DESCRIPTION
### Resolves

[M20-1278](https://robotical.atlassian.net/browse/M20-1278?atlOrigin=eyJpIjoiZWJiYzY5OGYyZDNjNDAzNTk3YmVlZTRhNThmN2EyMDgiLCJwIjoiaiJ9)

### Proposed Changes

made the div that encloses the items in the saved list scroll-able, so that when there are too many files to show users can scroll through them.

