### PR TITLE
M20-1438 Scratch Battery level colours don't match Robot's

### DIFF
--- a/src/components/marty-battery-level/marty-battery-level.jsx
+++ b/src/components/marty-battery-level/marty-battery-level.jsx
@@ -31,10 +31,10 @@ class MartyBatteryLevel extends React.Component {
     }
 
     getFillColor (batteryPercent) {
-        if (batteryPercent >= 70) {
+        if (batteryPercent >= 30) {
             return 'lime';
         }
-        if (batteryPercent >= 30) {
+        if (batteryPercent >= 10) {
             return 'rgb(255,215,0)';
         }
         return 'red';


### PR DESCRIPTION
### Resolves
Changed the threshold values that display battery level as a colour to match the robot's LED values
[M20-1438](https://robotical.atlassian.net/browse/M20-1438)